### PR TITLE
Add allowed <object> attributes in rich text

### DIFF
--- a/helpers/import/validationContentModels.js
+++ b/helpers/import/validationContentModels.js
@@ -125,7 +125,10 @@ function checkContentElementType(dataElement, modelElement) {
 function encapsulateRichText (dataElement, modelElement) {	
 	if (modelElement.type === 'rich_text') {
 		var clean = sanitizeHtml(dataElement, {
-			allowedTags: [ 'p', 'h1', 'h2', 'h3', 'h4', 'strong', 'a', 'em', 'ol', 'ul', 'li', 'table', 'tbody', 'td', 'td', 'figure', 'img', 'object', 'br' ]
+			allowedTags: [ 'p', 'h1', 'h2', 'h3', 'h4', 'strong', 'a', 'em', 'ol', 'ul', 'li', 'table', 'tbody', 'td', 'td', 'figure', 'img', 'object', 'br' ],
+			allowedAttributes: {
+				object: ['type', 'data-type', 'data-external-id', 'data-id']
+			}
 		});
 
 		return clean;


### PR DESCRIPTION
This should allow the allowed `object` attributes in rich text, as documented here: [Content items in Rich text](https://docs.kontent.ai/reference/management-api-v1#section/Rich-text-element/content-items-in-rich-text).

### Current behavior:
Given a valid project and content type, using a payload like this:
```json
{
   "items": [{
      "item": {
         "name": "test article 1",
         "type": {
            "codename": "article"
         },
         "external_id": "article1"
      },
      "variants": [{
         "language": {
            "codename": "default"
         },
         "elements": {
            "content": "<object type=\"application/kenticocloud\" data-type=\"item\" data-external-id=\"item123\"></object>"
         }
      }]
   }]
}
```
Produces the following log:
```
=== New data import at Wed, 18 Mar 2020 20:03:00 GMT===
Import data structure ok...
Import data and content models comparision ok...
Starting import...
Content item "test article 1"...
» Base data imported.
Import failed. Deleting already imported items...
Successfully deleted.
The provided request body is invalid. See the 'validation_errors' attribute for more information and specify a valid JSON object.
Invalid rich text value. The OBJECT element must have a 'type' attribute with a value 'application/kenticocloud', a 'data-type' attribute and a data attribute. Please see https://docs.kontent.ai/reference/management-api-v2#section/Rich-text-element.
```

### Expected behavior:
Payload response:
```json
{
   "message": [{
      "id": "0236c2c6-a676-5f42-8613-39580bf74d1b",
      "codename": "test_article_1"
   }]
}
```

This in the log:
```
=== New data import at Wed, 18 Mar 2020 20:04:58 GMT===
Import data structure ok...
Import data and content models comparision ok...
Starting import...
Content item "test article 1"...
» Base data imported.
» Language variants imported.
Import successful. See information about imported items in the code editor above.
```